### PR TITLE
Add support for Loading, Error and Empty Messages and Android Permissions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
       android:name=".MainApplication"

--- a/components/camera/CameraView.js
+++ b/components/camera/CameraView.js
@@ -37,6 +37,7 @@ export default class CameraView extends React.Component {
         if (granted === PermissionsAndroid.RESULTS.GRANTED) {
           await CameraRoll.saveToCameraRoll(data.uri);
         } else {
+          // This should probably be a toast notification since it is useless rn.
           this.setState({
             error: true,
             errorMessage: "Permissions not granted to save photos"

--- a/components/camera/CameraView.js
+++ b/components/camera/CameraView.js
@@ -1,13 +1,26 @@
 import React from "react";
-import { StyleSheet, TouchableOpacity, View, Dimensions } from "react-native";
+import {
+  StyleSheet,
+  TouchableOpacity,
+  View,
+  Dimensions,
+  CameraRoll,
+  PermissionsAndroid,
+  Platform
+} from "react-native";
 import { RNCamera } from "react-native-camera";
 
 import colors from "../../styles/colors";
+
 const window = Dimensions.get("window");
 
 export default class CameraView extends React.Component {
   camera = null;
 
+  state = {
+    error: null,
+    errorMessage: null
+  };
   // TODO: maybe all children should just do this by default HOC???
   componentDidMount() {
     this.props.shouldRenderBackButton(true, this.props.history);
@@ -17,7 +30,19 @@ export default class CameraView extends React.Component {
     if (this.camera) {
       const options = { quality: 0.5, base64: true };
       const data = await this.camera.takePictureAsync(options);
-      console.log(data.uri);
+      if (Platform.OS === "android") {
+        const granted = await PermissionsAndroid.request(
+          PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE
+        );
+        if (granted === PermissionsAndroid.RESULTS.GRANTED) {
+          await CameraRoll.saveToCameraRoll(data.uri);
+        } else {
+          this.setState({
+            error: true,
+            errorMessage: "Permissions not granted to save photos"
+          });
+        }
+      }
     }
   };
 

--- a/components/gallery/PhotoLibrary.js
+++ b/components/gallery/PhotoLibrary.js
@@ -10,7 +10,6 @@ import {
   CameraRoll,
   Platform
 } from "react-native";
-import { PermissionsAndroid } from "react-native";
 import Photo from "./Photo";
 
 const window = Dimensions.get("window");

--- a/components/gallery/PhotoLibrary.js
+++ b/components/gallery/PhotoLibrary.js
@@ -24,21 +24,7 @@ class PhotoLibrary extends Component {
   // TODO: maybe all children should just do this by default HOC???
   async componentDidMount() {
     this.props.shouldRenderBackButton(true, this.props.history);
-    if (Platform.OS === "android") {
-      const granted = await PermissionsAndroid.request(
-        PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE
-      );
-      if (granted === PermissionsAndroid.RESULTS.GRANTED) {
-        this.setState(await this.accessCameraRoll());
-      } else {
-        this.setState({
-          error: true,
-          errorMessage: "Permissions not granted to view photo library"
-        });
-      }
-    } else {
-      this.setState(await this.accessCameraRoll());
-    }
+    this.setState(await this.accessCameraRoll());
   }
 
   accessCameraRoll = () => {

--- a/components/gallery/PhotoLibrary.js
+++ b/components/gallery/PhotoLibrary.js
@@ -46,7 +46,7 @@ class PhotoLibrary extends Component {
       .then(photos =>
         Promise.resolve({
           photos: photos.edges,
-          message: photos.edges.length === 0 && "No pictures found!"
+          message: !photos.edges.length && "No pictures found!"
         })
       )
       .catch(e =>

--- a/components/gallery/PhotoLibrary.js
+++ b/components/gallery/PhotoLibrary.js
@@ -7,8 +7,7 @@ import {
   Text,
   View,
   ScrollView,
-  CameraRoll,
-  Platform
+  CameraRoll
 } from "react-native";
 import Photo from "./Photo";
 

--- a/components/gallery/PhotoLibrary.js
+++ b/components/gallery/PhotoLibrary.js
@@ -7,7 +7,9 @@ import {
   Text,
   View,
   ScrollView,
-  CameraRoll
+  CameraRoll,
+  Platform,
+  PermissionsAndroid
 } from "react-native";
 import Photo from "./Photo";
 
@@ -22,7 +24,21 @@ class PhotoLibrary extends Component {
   // TODO: maybe all children should just do this by default HOC???
   async componentDidMount() {
     this.props.shouldRenderBackButton(true, this.props.history);
-    this.setState(await this.accessCameraRoll());
+    if (Platform.OS === "android") {
+      const granted = await PermissionsAndroid.request(
+        PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE
+      );
+      if (granted === PermissionsAndroid.RESULTS.GRANTED) {
+        this.setState(await this.accessCameraRoll());
+      } else {
+        this.setState({
+          error: true,
+          errorMessage: "Permissions not granted to view photo library"
+        });
+      }
+    } else {
+      this.setState(await this.accessCameraRoll());
+    }
   }
 
   accessCameraRoll = () => {


### PR DESCRIPTION
Adds:
- Loading message
- Error message
- Empty message
- Check for Android Platform, if so, ask for necessary permissions in camera roll, then accessCameraRoll